### PR TITLE
Add CI/CD Cloud Build config

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -53,7 +53,7 @@ steps:
       - "-c"
       - |
         source .env.sh
-        gcloud app deplo
+        gcloud app deploy
     waitFor: ["collect-statics"]
 
 #substitutions:


### PR DESCRIPTION
In this PR I have added the Cloud Build configuration file.
As part of the config file creation efforts, I've reconfigured the Cloud Build trigger start only for the `master` branch in the GCP console.

The config has a commented-out section related to doing the DB migration. I guess it will be wise to not do the migration automatically. But if not, I'll uncomment the section and finish the configuration part (it'll require some changes to the `settings.py` as well).