### PR TITLE
Revert "Bump protobuf from 3.17.3 to 3.18.3"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ mccabe==0.6.1
 packaging==21.0
 Pillow==9.3.0
 pip==23.1.2
-protobuf==3.18.3
+protobuf==3.17.3
 psycopg2-binary==2.8.5
 pyasn1==0.4.8
 pyasn1-modules==0.2.8


### PR DESCRIPTION
google-api-core 1.31.3 depends on protobuf<3.18.0 and >=3.12.0