### PR TITLE
8685fnbbz project board link creator account

### DIFF
--- a/templates/projects/project-overview.html
+++ b/templates/projects/project-overview.html
@@ -18,7 +18,7 @@
             </td>
             <td>
                 {% for creator in project.project_creator_project.all %}
-                    {% if 'projects-board' in request.path%}
+                    {% if 'projects-board' in request.path %}
                         {% if creator.community %}
                             <a class="darkteal-text underline-hover bold pointer" href="{% url 'public-community' creator.community.id %}">
                                 {{ creator.community }}

--- a/templates/projects/project-overview.html
+++ b/templates/projects/project-overview.html
@@ -18,9 +18,27 @@
             </td>
             <td>
                 {% for creator in project.project_creator_project.all %}
-                    {% if creator.community %} {{ creator.community }} {% endif %}
-                    {% if creator.institution %} {{ creator.institution }} {% endif %}
-                    {% if creator.researcher %} {% firstof creator.researcher.user.get_full_name creator.researcher.user.username %} {% endif %}
+                    {% if 'projects-board' in request.path%}
+                        {% if creator.community %}
+                            <a class="darkteal-text underline-hover bold pointer" href="{% url 'public-community' creator.community.id %}">
+                                {{ creator.community }}
+                            </a>
+                        {% endif %}
+                        {% if creator.institution %} 
+                            <a class="darkteal-text underline-hover bold pointer" href="{% url 'public-institution' creator.institution.id %}"> 
+                                {{ creator.institution }}
+                            </a> 
+                        {% endif %}
+                        {% if creator.researcher %}
+                            <a class="darkteal-text underline-hover bold pointer" href="{% url 'public-researcher' creator.researcher.id %}"> 
+                                {% firstof creator.researcher.user.get_full_name creator.researcher.user.username %}
+                            </a>
+                        {% endif %}
+                    {% else %}
+                        {% if creator.community %} {{ creator.community }} {% endif %}
+                        {% if creator.institution %} {{ creator.institution }} {% endif %}
+                        {% if creator.researcher %} {% firstof creator.researcher.user.get_full_name creator.researcher.user.username %} {% endif %}
+                    {% endif %}
                 {% endfor %}
             </td>
             <td>{{ project.date_modified|date:'d M Y' }}</td>


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8685fnbbz)**

- When looking at the Projects Board `/projects-board/`, a user should be able to click on the creator account's name and be redirected to their Public page `/institutions/view/<id>/` , `/communities/view/<id>/ `, or `/researchers/view/<id>/ `, so the user can contact the accounts or view other information about them.

**Solution:**
- Added anchor tags with the link to respective public pages

**Video Demo:**
- Before:

<img width="1360" alt="project-board" src="https://github.com/biocodellc/localcontexts_db/assets/145371882/f6954a7f-7391-4080-99a2-87d7f9abfca5">


- After:


https://github.com/biocodellc/localcontexts_db/assets/145371882/ac52b70f-5385-488e-b3f8-f78b999e8207

