### PR TITLE
8685bwuqw-embed-labels-notices: Fixed embed url not taking url of hub instance

### DIFF
--- a/localcontexts/static/javascript/main.js
+++ b/localcontexts/static/javascript/main.js
@@ -1580,6 +1580,8 @@ if (window.location.href.includes('projects')) {
     var languageDropdown = document.getElementById('embedLanguageOptions')
     var langArray= new Array();
     var layoutType, languageType, customizationOptions = null
+    
+    embedCode.value = '<iframe width="560" height="250" src="http://'+window.location.host+'/projects/embed/f5850e3d-931e-46c0-9cb1-9969a4672271/" title="Local Contexts Project Identifiers" frameborder="0"></iframe>'
 
     for (i=0;i < languageDropdown.options.length; i++) {
         if (langArray.includes(languageDropdown.options[i].value) == false) {
@@ -1615,7 +1617,7 @@ if (window.location.href.includes('projects')) {
             customizationOptions = languageType
         }
 
-        embedCode.value = '<iframe width="560" height="250" src="http://localhost:8000/projects/embed/f5850e3d-931e-46c0-9cb1-9969a4672271?'+customizationOptions+'" title="Local Contexts Project Identifiers" frameborder="0"></iframe>'
+        embedCode.value = '<iframe width="560" height="250" src="http://'+window.location.host+'/projects/embed/f5850e3d-931e-46c0-9cb1-9969a4672271?'+customizationOptions+'" title="Local Contexts Project Identifiers" frameborder="0"></iframe>'
     }
 }
 

--- a/templates/partials/_project-actions.html
+++ b/templates/partials/_project-actions.html
@@ -702,7 +702,7 @@
                                 <p class="font-size-14 no-top-margin margin-bottom-8">Add this project's identifiers to your website by copying the code below.</p>
     
                                 <div class="text-input-to-copy">
-                                    <input class="w-100 grey-chip" type="text" value='<iframe width="560" height="250" src="http://localhost:8000/projects/embed/f5850e3d-931e-46c0-9cb1-9969a4672271/" title="Local Contexts Project Identifiers" frameborder="0"></iframe>' id="projectPageEmbedToCopy" readonly>
+                                    <input class="w-100 grey-chip" type="text" value='' id="projectPageEmbedToCopy" readonly>
                                     <button class="copy-btn btn-in-input" data-target="projectPageEmbedToCopy">Copy Code</button>
                                 </div>
                                 <p class="font-size-14 margin-top-1 no-bottom-margin">Embed Options</p>


### PR DESCRIPTION
Fixed issue where the project embed source URL was not taking the URL location of the hub instance.

New expected behavior: 
- On local server, localserver URL used in embed code
- In test Hub, test Hub URL used in embed code
- In production Hub, production Hub URL used in embed code