### PR TITLE
86864jmww-sandbox-banner-announcement

### DIFF
--- a/localcontexts/static/css/modals.css
+++ b/localcontexts/static/css/modals.css
@@ -42,6 +42,7 @@
 .notice-modal { width: 700px; }
 /* PROJECT ACTION PAGE: UNLINK PROJECT */
 .project-unlink-modal { width: 680px; height: 202px; }
+.announcement-modal { width: 680px;}
 
 /* PROJECT ACTION PAGE: SHARE PROJECT MODAL */
 .share-project-modal { width: 700px; height: auto; }

--- a/templates/accounts/login.html
+++ b/templates/accounts/login.html
@@ -48,4 +48,7 @@
         {% endif %}
 
     </div>
+
+    {% include 'partials/modals/_announcement-modal.html' %}
+
 {% endblock %}

--- a/templates/accounts/register.html
+++ b/templates/accounts/register.html
@@ -87,4 +87,6 @@
     </form>
 </div>
 
+{% include 'partials/modals/_announcement-modal.html' %}
+
 {% endblock %}

--- a/templates/partials/banners/_sandbox-banner.html
+++ b/templates/partials/banners/_sandbox-banner.html
@@ -1,9 +1,7 @@
 {% load static %}
 
 <div class="sandbox-container">
-    <p class="block">Warning! anth-ja77-lc-dev-42d5.uc.r.appspot.com is a test website that is only used to test workflows.
-        <strong>localcontextshub.org</strong> is the official site.
-    </p>
+    <p class="block">Warning! anth-ja77-lc-dev-42d5.uc.r.appspot.com is permanently moving to <a href="https://sandbox.localcontextshub.org/login/" rel="me noopener noreferrer" class="underline-hover bold">sandbox.localcontextshub.org <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>. Please sign in or register there.</p>
 </div>
 
 <style>

--- a/templates/partials/modals/_announcement-modal.html
+++ b/templates/partials/modals/_announcement-modal.html
@@ -1,0 +1,55 @@
+{% load static %}
+
+<div id="announcementModal" class="modal">
+
+    <div class="modal-defaults announcement-modal flex-this column w-100">
+        <div class="w-100">
+
+            <div>
+                <h2 class="primary-black-text no-top-margin">Important Sandbox Announcement</h2>  
+                <p>
+                    The anth-ja77-lc-dev-42d5.uc.r.appspot.com URL will be <strong>deactivated on November 7th, 2023</strong>.
+                    The test/sandbox hub will only be available at <strong>sandbox.localcontextshub.org</strong>. <br><br>
+
+                    If you are not using the API, please start using the new Sandbox Hub today.
+
+
+                    <h3>In the new sandbox location you will:</h3>
+                    <ul>
+                        <li>Still be able to login with the same credentials you've used on this site.</li>
+                        <li>Retain all your test accounts and Projects created on or before Oct 20th, 2023.</li>
+                    </ul>
+
+                    <h3>This will affect the test API in the following ways:</h3>
+                    If you are using any of these links directly in your API connections, please make sure to update them.<br>
+
+                    <ul>
+                        <li>
+                            For test hub API calls, update the domain from anth-ja77-lc-dev-42d5.uc.r.appspot.com to sandbox.localcontextshub.org. 
+                        </li>
+                        <li>
+                            For Labels and Notices applied to your Projects, the img_url and svg_url fields have changed.
+                        </li>
+                    </ul>
+
+                    For any additional assistance or questions, please email us at support@localcontexts.org.
+
+                </p>  
+            </div>
+            <div class="flex-this w-100 text-align-center">
+                <div id="dismissAnnouncementBtn" class="primary-btn white-btn margin-right-1">Dismiss</div>    
+                <a href="https://sandbox.localcontextshub.org/" rel="me noopener noreferrer" class="margin-left-1 primary-btn action-btn">Redirect me to the sandbox</a>
+            </div>
+
+        </div>
+    </div>
+</div>
+
+<script>
+    const announcementModal = document.getElementById('announcementModal')
+    const dismissBtn = document.getElementById('dismissAnnouncementBtn')
+
+    dismissBtn.addEventListener('click', function() {
+        announcementModal.classList.add('hide')
+    })
+</script>


### PR DESCRIPTION
Adjusted the sandbox banner to redirect users to sandbox.localcontextshub.org and created a modal for login and register pages. When dismissed, it will hide but when the login or register page is refreshed it will reappear again to encourage users to use the new sandbox.

<img width="1402" alt="Screenshot 2023-10-24 at 12 39 49 PM" src="https://github.com/biocodellc/localcontexts_db/assets/41635757/f08ffef7-f764-43c5-9088-1df64cd5a0e5">
