### PR TITLE
Resolved Dependabot Security Vulnerability 43

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 appdirs==1.4.4
-arabic-reshaper==2.1.3
+arabic-reshaper==3.0.0
 asgiref==3.2.10
 astroid==2.4.2
 boto3==1.26.77
@@ -56,7 +56,7 @@ pytest-runner==5.3.1
 python-bidi==0.4.2
 python-dateutil==2.8.1
 pytz==2020.1
-reportlab==3.6.2
+reportlab>=3.6.13
 requests==2.31.0
 rsa==4.7.2
 s3transfer==0.6.0
@@ -71,4 +71,4 @@ webencodings==0.5.1
 wheel==0.38.1
 whitenoise==5.2.0
 wrapt==1.12.1
-xhtml2pdf==0.2.5
+xhtml2pdf==0.2.11


### PR DESCRIPTION
Fixes security  [vulnerability](https://github.com/biocodellc/localcontexts_db/security/dependabot/43) discovered by dependabot caused by uploading a well-crafted pdf.

* In order to update `reportlab`, `arabic-reshaper` and `xhtml2pdf` needed to be updated as well.